### PR TITLE
Keep the popup and group page live via chrome.storage.onChanged

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ server, no account, and no analytics, and makes no network requests of its own.
   from the group page. Tabs are opened one by one, so one bad URL cannot fail
   the whole restore.
 - **Search** — filter across group names, tab titles and URLs.
+- **Live updates** — the popup and any open group page stay in sync with each
+  other; renaming or deleting in one shows up in the other immediately.
 - **Import / export** — JSON files, including the flat `[{title, url}]` format
   written by earlier versions of this extension.
 
@@ -132,7 +134,6 @@ disclosures and the assets still to produce — is in
 
 - [ ] Store assets: screenshots and the 440×280 promo tile
 - [ ] Keyboard shortcut and context-menu entry
-- [ ] Live popup refresh via `chrome.storage.onChanged`
 - [ ] Firefox and Edge builds
 
 ---

--- a/WARP.md
+++ b/WARP.md
@@ -58,6 +58,18 @@ Handlers: `save_tab_group`, `get_all_groups`, `restore_tab_group`,
 `update_group_name`, `export_group`, `export_all_groups`, `import_groups`,
 `get_storage_stats`.
 
+### Live updates
+
+Messages go one way, in; state comes back out through
+`chrome.storage.onChanged`, wrapped by `utils/storageEvents.js`. The popup and
+the group page each subscribe once and re-render from the event payload, so a
+change made in one context appears in the other without polling.
+
+The practical rule: **do not refetch after a mutation.** A successful handler
+writes to storage, the write fires the event, and every open view updates
+itself. Adding a manual refresh on top produces a redundant round trip and a
+second render.
+
 ### Trust boundaries
 
 - Imported JSON is untrusted. It goes through `normalizeImport` in

--- a/config/jest/setupTests.js
+++ b/config/jest/setupTests.js
@@ -17,6 +17,20 @@ const createStorageArea = () => {
   };
 };
 
+/** Stand-in for a chrome.events.Event, with a hook for firing it in tests. */
+const createEvent = () => {
+  const listeners = new Set();
+  return {
+    addListener: jest.fn((listener) => listeners.add(listener)),
+    removeListener: jest.fn((listener) => listeners.delete(listener)),
+    hasListeners: () => listeners.size > 0,
+    __emit: (...args) => {
+      for (const listener of [...listeners]) listener(...args);
+    },
+    __reset: () => listeners.clear(),
+  };
+};
+
 global.chrome = {
   runtime: {
     id: "vtabs-test",
@@ -26,7 +40,7 @@ global.chrome = {
     getURL: (path) =>
       `chrome-extension://vtabs-test/${path.replace(/^\//, "")}`,
   },
-  storage: { local: createStorageArea() },
+  storage: { local: createStorageArea(), onChanged: createEvent() },
   tabs: {
     query: jest.fn(async () => []),
     create: jest.fn(async () => ({ id: 1 })),
@@ -38,6 +52,9 @@ global.chrome = {
 
 beforeEach(() => {
   chrome.storage.local.__reset();
+  chrome.storage.onChanged.__reset();
   chrome.runtime.lastError = undefined;
+  // clearAllMocks, not resetAllMocks: the mock implementations above have to
+  // survive between tests.
   jest.clearAllMocks();
 });

--- a/src/components/Pages/TabGroups/TabGroupList.js
+++ b/src/components/Pages/TabGroups/TabGroupList.js
@@ -3,6 +3,7 @@ import { Alert, Button, Form, InputGroup, Spinner } from "react-bootstrap";
 import TabGroupItem from "../../Shared/TabGroupItem";
 import SaveTabsModal from "../../Shared/SaveTabsModal";
 import { sendMessage } from "../../../utils/messaging";
+import { onGroupsChanged } from "../../../utils/storageEvents";
 import { assertImportSize } from "../../../utils/validation";
 import "./TabGroupList.css";
 
@@ -45,6 +46,12 @@ const TabGroupList = () => {
     loadGroups();
   }, [loadGroups]);
 
+  // Every mutation goes through the service worker, which writes to storage,
+  // so watching storage keeps this list current no matter which context made
+  // the change — including the group page in another tab. Nothing below needs
+  // to refetch after acting.
+  useEffect(() => onGroupsChanged(setGroups), []);
+
   // Derived, not stored: keeping a second copy of the list in state meant the
   // two could drift apart whenever a mutation landed mid-search.
   const filteredGroups = useMemo(() => {
@@ -74,7 +81,6 @@ const TabGroupList = () => {
       tone: "success",
       text: `Saved ${response.group.tabs.length} tabs.${skipped}`,
     });
-    await loadGroups();
   };
 
   const handleExportAll = async () => {
@@ -109,7 +115,6 @@ const TabGroupList = () => {
             : ""
         }`,
       });
-      await loadGroups();
     } catch (error) {
       const text =
         error instanceof SyntaxError
@@ -155,9 +160,6 @@ const TabGroupList = () => {
             disabled={groups.length === 0}
           >
             Export all
-          </Button>
-          <Button variant="outline-secondary" onClick={loadGroups}>
-            Refresh
           </Button>
           <input
             ref={fileInputRef}
@@ -227,7 +229,6 @@ const TabGroupList = () => {
             <TabGroupItem
               key={group.id}
               group={group}
-              onChanged={loadGroups}
               onError={(message) =>
                 setNotice({ tone: "danger", text: message })
               }

--- a/src/components/Pages/TabGroups/TabGroupList.test.js
+++ b/src/components/Pages/TabGroups/TabGroupList.test.js
@@ -1,5 +1,14 @@
-import { render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import TabGroupList from "./TabGroupList";
+
+const emitGroups = async (groups) => {
+  await act(async () => {
+    chrome.storage.onChanged.__emit(
+      { tabGroups: { newValue: groups } },
+      "local",
+    );
+  });
+};
 
 const respondWith = (responses) => {
   chrome.runtime.sendMessage.mockImplementation((message, callback) => {
@@ -50,5 +59,54 @@ describe("TabGroupList", () => {
     render(<TabGroupList />);
 
     expect(await screen.findByText(/worker is asleep/)).toBeInTheDocument();
+  });
+
+  it("picks up a change made in another context without being asked", async () => {
+    respondWith({ get_all_groups: { success: true, groups: [] } });
+
+    render(<TabGroupList />);
+    expect(await screen.findByText("No saved groups yet")).toBeInTheDocument();
+
+    // e.g. the group page deleted a tab, or a save happened in another window.
+    await emitGroups([
+      {
+        id: "g1",
+        name: "Arrived later",
+        timestamp: 1700000000000,
+        tabs: [{ id: "t1", title: "One", url: "https://one.example" }],
+      },
+    ]);
+
+    expect(screen.getByText("Arrived later")).toBeInTheDocument();
+    expect(screen.getByText("1 group")).toBeInTheDocument();
+    expect(screen.queryByText("No saved groups yet")).not.toBeInTheDocument();
+  });
+
+  it("empties the list when every group is deleted elsewhere", async () => {
+    respondWith({
+      get_all_groups: {
+        success: true,
+        groups: [{ id: "g1", name: "Doomed", timestamp: 1, tabs: [] }],
+      },
+    });
+
+    render(<TabGroupList />);
+    expect(await screen.findByText("Doomed")).toBeInTheDocument();
+
+    await emitGroups([]);
+
+    expect(screen.getByText("No saved groups yet")).toBeInTheDocument();
+  });
+
+  it("unsubscribes on unmount", async () => {
+    respondWith({ get_all_groups: { success: true, groups: [] } });
+
+    const { unmount } = render(<TabGroupList />);
+    await screen.findByText("No saved groups yet");
+    expect(chrome.storage.onChanged.hasListeners()).toBe(true);
+
+    unmount();
+
+    expect(chrome.storage.onChanged.hasListeners()).toBe(false);
   });
 });

--- a/src/components/Shared/TabGroupItem.js
+++ b/src/components/Shared/TabGroupItem.js
@@ -3,16 +3,19 @@ import { Badge, Button, Form } from "react-bootstrap";
 import { sendMessage } from "../../utils/messaging";
 import "./TabGroupItem.css";
 
-/** One saved group: name, counts, and the actions that operate on it. */
-const TabGroupItem = ({ group, onChanged, onError }) => {
+/**
+ * One saved group: name, counts, and the actions that operate on it.
+ *
+ * Nothing here tells the list to refresh — the list watches storage, so a
+ * successful mutation re-renders it on its own.
+ */
+const TabGroupItem = ({ group, onError }) => {
   const [isEditing, setIsEditing] = useState(false);
   const [editedName, setEditedName] = useState(group.name);
 
-  const run = async (message, { refresh = false } = {}) => {
+  const run = async (message) => {
     try {
-      const response = await sendMessage(message);
-      if (refresh) onChanged();
-      return response;
+      return await sendMessage(message);
     } catch (error) {
       onError(error.message);
       return null;
@@ -34,10 +37,7 @@ const TabGroupItem = ({ group, onChanged, onError }) => {
     ) {
       return;
     }
-    run(
-      { action: "restore_tab_group", groupId: group.id, deleteAfterRestore },
-      { refresh: deleteAfterRestore },
-    );
+    run({ action: "restore_tab_group", groupId: group.id, deleteAfterRestore });
   };
 
   const handleDelete = () => {
@@ -48,7 +48,7 @@ const TabGroupItem = ({ group, onChanged, onError }) => {
     ) {
       return;
     }
-    run({ action: "delete_tab_group", groupId: group.id }, { refresh: true });
+    run({ action: "delete_tab_group", groupId: group.id });
   };
 
   const handleRename = () => {
@@ -59,10 +59,7 @@ const TabGroupItem = ({ group, onChanged, onError }) => {
       setEditedName(group.name);
       return;
     }
-    run(
-      { action: "update_group_name", groupId: group.id, newName: name },
-      { refresh: true },
-    );
+    run({ action: "update_group_name", groupId: group.id, newName: name });
   };
 
   return (

--- a/src/group-view.js
+++ b/src/group-view.js
@@ -9,6 +9,7 @@
 import "./group-view.css";
 import { faviconUrl } from "./utils/favicon";
 import { sendMessage } from "./utils/messaging";
+import { onGroupsChanged } from "./utils/storageEvents";
 
 const groupId = new URLSearchParams(window.location.search).get("id");
 
@@ -78,9 +79,8 @@ const createTabItem = (tab) => {
         groupId,
         tabId: tab.id,
       });
-      // Deleting the last tab deletes the group, so re-read rather than
-      // patching the DOM and guessing.
-      await loadGroup();
+      // The storage subscription re-renders the list, including the case
+      // where that was the last tab and the group no longer exists.
       showStatus("Tab removed.");
     } catch (error) {
       showStatus(`Could not remove that tab: ${error.message}`, "error");
@@ -132,6 +132,17 @@ const restoreAll = async (deleteAfterRestore) => {
   }
 };
 
+const render = (groups) => {
+  currentGroup = groups.find((group) => group.id === groupId);
+
+  if (!currentGroup) {
+    showError();
+    return;
+  }
+
+  displayGroup(currentGroup);
+};
+
 const loadGroup = async () => {
   if (!groupId) {
     showError();
@@ -140,25 +151,22 @@ const loadGroup = async () => {
 
   try {
     const { groups } = await sendMessage({ action: "get_all_groups" });
-    currentGroup = groups.find((group) => group.id === groupId);
-
-    if (!currentGroup) {
-      showError();
-      return;
-    }
-
-    displayGroup(currentGroup);
+    render(groups);
   } catch (error) {
     console.error("vTabs: could not load group", error);
     showError();
   }
 };
 
-// Bound once: loadGroup() re-runs after edits and would otherwise stack up
-// duplicate listeners.
+// Bound once: the list re-renders on every storage change and would otherwise
+// stack up duplicate listeners.
 el("restoreAllBtn").addEventListener("click", () => restoreAll(false));
 el("restoreAndDeleteBtn").addEventListener("click", () => restoreAll(true));
 el("backBtn").addEventListener("click", () => window.close());
 el("errorCloseBtn").addEventListener("click", () => window.close());
+
+// Keeps this page current when the popup, or another copy of this page,
+// renames or deletes something.
+onGroupsChanged(render);
 
 loadGroup();

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,0 +1,2 @@
+/** The single chrome.storage.local key holding every saved group. */
+export const STORAGE_KEY = "tabGroups";

--- a/src/utils/storage.js
+++ b/src/utils/storage.js
@@ -9,9 +9,8 @@
  * covers every writer.
  */
 
+import { STORAGE_KEY } from "./constants";
 import { normalizeImport } from "./validation";
-
-const STORAGE_KEY = "tabGroups";
 
 let writeQueue = Promise.resolve();
 

--- a/src/utils/storageEvents.js
+++ b/src/utils/storageEvents.js
@@ -1,0 +1,30 @@
+import { STORAGE_KEY } from "./constants";
+
+/**
+ * Subscribe to saved-group changes.
+ *
+ * chrome.storage.onChanged fires in every extension context, so a change made
+ * by the service worker on behalf of the group page reaches an open popup too.
+ * The event carries the new value, so no message round trip is needed to find
+ * out what changed.
+ *
+ * Reading here does not break the single-writer rule: writes still go through
+ * the background, this only observes the result.
+ *
+ * @param {(groups: object[]) => void} listener
+ * @returns {() => void} unsubscribe
+ */
+export const onGroupsChanged = (listener) => {
+  const handler = (changes, areaName) => {
+    if (areaName !== "local") return;
+
+    const change = changes[STORAGE_KEY];
+    if (!change) return;
+
+    // newValue is absent when the key is removed entirely.
+    listener(Array.isArray(change.newValue) ? change.newValue : []);
+  };
+
+  chrome.storage.onChanged.addListener(handler);
+  return () => chrome.storage.onChanged.removeListener(handler);
+};

--- a/src/utils/storageEvents.test.js
+++ b/src/utils/storageEvents.test.js
@@ -1,0 +1,60 @@
+import { onGroupsChanged } from "./storageEvents";
+
+const groups = [{ id: "g1", name: "Work", timestamp: 1, tabs: [] }];
+
+describe("onGroupsChanged", () => {
+  it("reports the new group list", () => {
+    const listener = jest.fn();
+    onGroupsChanged(listener);
+
+    chrome.storage.onChanged.__emit(
+      { tabGroups: { newValue: groups } },
+      "local",
+    );
+
+    expect(listener).toHaveBeenCalledWith(groups);
+  });
+
+  it("reports an empty list when the key is removed", () => {
+    const listener = jest.fn();
+    onGroupsChanged(listener);
+
+    // A removed key arrives as a change with no newValue.
+    chrome.storage.onChanged.__emit(
+      { tabGroups: { oldValue: groups } },
+      "local",
+    );
+
+    expect(listener).toHaveBeenCalledWith([]);
+  });
+
+  it("ignores other storage areas and other keys", () => {
+    const listener = jest.fn();
+    onGroupsChanged(listener);
+
+    chrome.storage.onChanged.__emit(
+      { tabGroups: { newValue: groups } },
+      "sync",
+    );
+    chrome.storage.onChanged.__emit(
+      { somethingElse: { newValue: 1 } },
+      "local",
+    );
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it("stops listening once unsubscribed", () => {
+    const listener = jest.fn();
+    const unsubscribe = onGroupsChanged(listener);
+
+    unsubscribe();
+    chrome.storage.onChanged.__emit(
+      { tabGroups: { newValue: groups } },
+      "local",
+    );
+
+    expect(listener).not.toHaveBeenCalled();
+    expect(chrome.storage.onChanged.hasListeners()).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes the "live popup refresh" roadmap item.

Both views could show stale data. The popup only reloaded when told to, so deleting a tab on the group page left its counts wrong until you pressed Refresh — and the group page never noticed a rename made in the popup at all.

## Approach

Messages go one way, in; state comes back out through `chrome.storage.onChanged`.

- **`utils/storageEvents.js`** subscribes to the event, filters to the `local` area and the groups key, and hands the listener the new value. The event already carries it, so there is no round trip back to the service worker.
- **`utils/constants.js`** now owns the storage key, so the subscriber can share it without importing the background's write layer — which would have put `deleteGroup` and friends within reach of UI code and undermined the single-writer invariant that makes the write queue sufficient.
- **`TabGroupList`** and **`group-view.js`** each subscribe once and re-render from the payload.

## What that removes

Because a successful mutation writes to storage, and the write fires the event, every explicit refetch was redundant:

- both `await loadGroups()` calls after save and import
- `TabGroupItem`'s `onChanged` prop and the `refresh` option on its message helper
- the **Refresh button**, which existed only because the list could go stale

## Tests

The jest `chrome` mock grows an event stand-in with `__emit` / `hasListeners`. 23 → 30 tests, covering area and key filtering, the removed-key case, unsubscribe on unmount, and both views reacting to a change made in another context.

Lint, format, build and tests all clean.